### PR TITLE
feat: harden search, frontend escaping, and tests

### DIFF
--- a/.claude/skills/project-guide/SKILL.md
+++ b/.claude/skills/project-guide/SKILL.md
@@ -126,7 +126,9 @@ docker compose up --build   # Docker deployment
 3. Always sanitize paths before filesystem access
 4. Broadcast all mutations via WebSocket
 5. Use env vars for config with sensible defaults
+6. **Use TLDR before reading files** — see tldr-first skill
 
 ## Related Skills
+- **tldr-first**: Token-efficient exploration (TLDR commands first)
 - **ui-patterns**: Frontend CSS/JS patterns
 - **quality-checklist**: Pre-commit verification

--- a/static/index.html
+++ b/static/index.html
@@ -3820,9 +3820,11 @@
 
         function escapeAttr(str) {
             return str
-                .replace(/\\/g, '\\\\')  // Escape backslashes first
-                .replace(/'/g, "\\'")    // Escape single quotes for JS strings
-                .replace(/"/g, '&quot;'); // Escape double quotes for HTML attributes
+                .replace(/\\/g, '\\\\')   // Escape backslashes first
+                .replace(/'/g, "\\'")     // Escape single quotes for JS strings
+                .replace(/"/g, '&quot;')  // Escape double quotes for HTML attributes
+                .replace(/`/g, '\\`')     // Escape backticks for template literals
+                .replace(/\$/g, '\\$');   // Escape $ to prevent template interpolation
         }
 
         // Drag & Drop zone

--- a/tests/ui.spec.ts
+++ b/tests/ui.spec.ts
@@ -7,7 +7,7 @@ async function writeFixture(path: string, contents: string) {
 
 test('loads the home screen', async ({ page }) => {
   await page.goto('/');
-  await expect(page.getByText('Boxy')).toBeVisible();
+  await expect(page.getByRole('banner').getByText('Boxy')).toBeVisible();
   await expect(page.getByText('Drop files here, click Upload, or paste from clipboard')).toBeVisible();
 });
 


### PR DESCRIPTION
- backend: cap search results to prevent runaway traversal
- security: preserve resolve_path_safe across all fs handlers
- frontend: harden escapeAttr for template literal safety
- tests: stabilize UI selectors for e2e reliability
- docs: align project-guide skill with TLDR workflow